### PR TITLE
build: Add requirements using a pyproject.toml file and poetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,5 @@ cython_debug/
 
 # macOS
 .DS_Store
+poetry.lock
+.python-version

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,3 @@
+[virtualenvs]
+create = true
+in-project = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "historyaitoolkit"
+version = "0.0.1"
+description = "AI toolkit for professional and amateur historians, and for anyone who wishes to contribute to the recording of history by and for the community."
+authors = ["Audrey Roy Greenfeld <audrey@feldroy.com>"]
+readme = "README.md"
+license= "GPL-2.0-or-later"
+
+[tool.poetry.dependencies]
+python = "^3.11"
+openai = "^0.28.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4.2"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+aiohttp==3.8.5
+aiosignal==1.3.1
+async-timeout==4.0.3
+attrs==23.1.0
+certifi==2023.7.22
+charset-normalizer==3.2.0
+colorama==0.4.6
+frozenlist==1.4.0
+idna==3.4
+multidict==6.0.4
+openai==0.28.0
+requests==2.31.0
+tqdm==4.66.1
+urllib3==2.0.5
+yarl==1.9.2


### PR DESCRIPTION
I am getting an error when trying to add dotenv:
```AttributeError: module 'setuptools' has no attribute '_install_setup_requires'```
with the note:
```Note: This error originates from the build backend, and is likely not a problem with poetry but with dotenv (0.0.5) not supporting PEP 517 builds. You can verify this by running 'pip wheel --use-pep517 "dotenv (==0.0.5)"```

I therefore ignored dotenv for now, since it still has not been settled wether to use dotenv for handling environment variables