### PR TITLE
Use pydantic BaseSettings for managing environment varibles

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,16 @@ https://www.kaggle.com/datasets/audreyfeldroy/oral-history-audio-interviews
 
 Sample oral history interviews, some with transcripts we can work with:
 * https://wayback.archive-it.org/14173/20200827171043/http://transcribe.oralhistory.nypl.org/
+
+## Getting started
+
+To get started, you can either install it using `poetry` and running`
+```
+poetry install
+```
+or you can use `pip` and run
+```
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```

--- a/interviewkit/main.py
+++ b/interviewkit/main.py
@@ -6,17 +6,18 @@ import openai
 from interview import Interview
 from interviewee import Interviewee
 from transcript import Transcript
+from settings import Settings
 
 
 # Load the .env file into the environment
 load_dotenv()
 
 # Set the OpenAI API key
-openai.api_key = os.getenv("OPENAI_API_KEY")
+settings = Settings()
+openai.api_key = settings.OPENAI_API_KEY
 
 
 if __name__ == "__main__":
-
     interviewee = Interviewee("John Doe", 60, "Male")
 
     transcript_content = "This is the content of the transcript."

--- a/interviewkit/settings.py
+++ b/interviewkit/settings.py
@@ -1,0 +1,5 @@
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    OPENAI_API_KEY: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ license= "GPL-2.0-or-later"
 [tool.poetry.dependencies]
 python = "^3.11"
 openai = "^0.28.0"
+pydantic-settings = "^2.0.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.2"


### PR DESCRIPTION
Check out https://docs.pydantic.dev/latest/usage/pydantic_settings/
A better, and type checked, way of handling environment variables. Secondly, you avoid the error `not supporting PEP 517 builds` when trying to install dotenv (using poetry)