### PR TITLE
Add README to docs

### DIFF
--- a/docs/source/README_link.md
+++ b/docs/source/README_link.md
@@ -1,0 +1,5 @@
+<!-- markdownlint-disable -->
+
+```{include} ../../README.md
+
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,23 +6,22 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'HistoryAIToolKit'
-copyright = '2023, Audrey Roy Greenfeld'
-author = 'Audrey Roy Greenfeld'
-release = '0.0.1'
+project = "HistoryAIToolKit"
+copyright = "2023, Audrey Roy Greenfeld"
+author = "Audrey Roy Greenfeld"
+release = "0.0.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = []
+extensions = ["myst_parser"]
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 exclude_patterns = []
-
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
-html_static_path = ['_static']
+html_theme = "alabaster"
+html_static_path = ["_static"]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,3 +17,12 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
+
+
+Contents:
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   README_link

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ pydantic = "^2.3.0"
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.2"
 sphinx = "^7.2.6"
+myst-parser = "^2.0.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
With a strange hack, I had to to add an extra MD file inside the docs folder that points the root README.md file. Seems to work as intented though