### PR TITLE
Remove enum dependency and add installation test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "pydub==0.25.1",
     "rich==13.6.0",
     "pathlib==1.0.1",
-    "enum==0.4.7",
+  
 ]
 
 [project.optional-dependencies]
@@ -39,6 +39,11 @@ dev = [
     "pytest",  # testing
     "ruff",  # linting
     "sphinx"  # documentation
+]
+
+test = [
+    "pytest",
+    # other test dependencies
 ]
 
 [project.urls]

--- a/tests/test_install_package.py
+++ b/tests/test_install_package.py
@@ -1,0 +1,36 @@
+import subprocess
+import unittest
+import os
+import shutil
+import sys
+
+class TestInstallPackage(unittest.TestCase):
+
+    def setUp(self):
+        # Create a virtual environment
+        subprocess.run([sys.executable, "-m", "venv", ".venv"], check=True)
+        
+    def tearDown(self):
+        # Clean up: Remove the virtual environment directory after the test
+        shutil.rmtree(".venv")
+        
+    def test_install_in_editable_mode(self):
+        # Activate the virtual environment
+        activate_script = ".venv/bin/activate" if os.name == "posix" else ".venv\\Scripts\\activate"
+        shell = False if os.name == "posix" else True
+        
+        # Commands to run
+        commands = [
+            f"source {activate_script}",
+            "pip install -e '.[test]'"
+        ]
+        
+        # Run the commands
+        process = subprocess.Popen(["/bin/bash", "-c", " && ".join(commands)], shell=shell)
+        process.communicate()
+        
+        # Check if the process was successful
+        self.assertEqual(process.returncode, 0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Removed the `enum` package from dependencies due to conflicts with the built-in Python module.
- Added a test to verify that the package can be installed in editable mode with test dependencies.