### PR TITLE
Version option and fixes relative imports

### DIFF
--- a/src/interviewkit/__init__.py
+++ b/src/interviewkit/__init__.py
@@ -1,0 +1,1 @@
+import os, sys; sys.path.append(os.path.dirname(os.path.realpath(__file__)))

--- a/src/interviewkit/cli.py
+++ b/src/interviewkit/cli.py
@@ -1,10 +1,8 @@
-from pathlib import Path
-
-from rich import print
-import typer
-from typing import Optional
-from typing_extensions import Annotated
 import sys
+import typer
+
+from pathlib import Path
+from typing_extensions import Annotated
 
 from slicer import audio_slicing
 from transcript import transcribe_from_paths

--- a/src/interviewkit/cli.py
+++ b/src/interviewkit/cli.py
@@ -4,12 +4,25 @@ from rich import print
 import typer
 from typing import Optional
 from typing_extensions import Annotated
+import sys
 
-from .slicer import audio_slicing
-from .transcript import transcribe_from_paths
+from slicer import audio_slicing
+from transcript import transcribe_from_paths
+
+
+__version__ = '0.0.1'
 
 app = typer.Typer()
 
+def version_callback(value: bool):
+    if value:
+        typer.echo(f"HistoryAIToolKit: {__version__}")
+        raise typer.Exit()
+
+@app.command("version")    
+def main():
+    """Checks the package version"""
+    version_callback(sys.argv[1:])
 
 @app.command()
 def slice(

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,16 @@
+import unittest
+import subprocess
+
+class TestCLIVersion(unittest.TestCase):
+    
+    def test_version_option(self):
+        # Run the CLI command and capture its output
+        result = subprocess.run(["python", "-m", "src.interviewkit.cli", "version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+
+        self.assertEqual(result.returncode, 0)
+
+        # Check if the version number is correct
+        self.assertIn(f"HistoryAIToolKit: 0.0.1", result.stdout)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Addresses: https://github.com/audreyfeldroy/HistoryAIToolkit/issues/56

`--version` with typer wouldn't work no matter what approach I took. `version` will keep the same uniform with the other commands.