### PR TITLE
Generalise slicer

### DIFF
--- a/src/interviewkit/slicer.py
+++ b/src/interviewkit/slicer.py
@@ -74,23 +74,23 @@ def parse_input(argv: list[str]):
     return SlicerInput(path, audio_start_time, audio_end_time)
 
 def create_output_path(input: SlicerInput):
-    start_time_output = f'{input.start_time.min}m{input.start_time.seconds}s'
-    end_time_output = f'{input.end_time.min}m{input.end_time.seconds}s'
-    new_filepath =  input.path.name + f"/sampled-{start_time_output}-{end_time_output}-{self.name}"
+    start_minutes, start_seconds = divmod(input.start_time.seconds, 60)
+    end_minutes, end_seconds = divmod(input.end_time.seconds, 60)
+    start_time_output = f'{start_minutes}m{start_seconds}s'
+    end_time_output = f'{end_minutes}m{end_seconds}s'
+    new_filepath =   input.path.parent / f"sampled-{start_time_output}-{end_time_output}-{input.path.name}"
     return new_filepath
 
 def slice_audio(audio: pydub.AudioSegment, start_time: timedelta , end_time: timedelta):
     start_time_ms = int(start_time.total_seconds() * 1000)
     end_time_ms = int(end_time.total_seconds() * 1000)
     
-    return audio[start_time_ms, end_time_ms]
+    return audio[start_time_ms:end_time_ms]
 
 
 def main():
 
     argv = parse_input(sys.argv)
-
-    print(argv.path)
 
     audio = pydub.AudioSegment.from_file(argv.path)
 
@@ -102,7 +102,7 @@ def main():
     output_file_path = create_output_path(argv)
     sliced_audio.export(output_file_path, "mp3")
 
-    logging.log(f'Created new file: {output_file_path}')
+    print(f'Created new file: {output_file_path}')
 
 
 if __name__ == '__main__':

--- a/src/interviewkit/slicer.py
+++ b/src/interviewkit/slicer.py
@@ -82,6 +82,11 @@ def create_output_path(input: SlicerInput):
     return new_filepath
 
 def slice_audio(audio: pydub.AudioSegment, start_time: timedelta , end_time: timedelta):
+
+
+    if(start_time.seconds > audio.duration_seconds or end_time.seconds > audio.duration_seconds):
+        raise ValueError("slice not within audio length")
+
     start_time_ms = int(start_time.total_seconds() * 1000)
     end_time_ms = int(end_time.total_seconds() * 1000)
     
@@ -96,7 +101,7 @@ def main():
 
     try:
        sliced_audio =  slice_audio(audio, argv.start_time, argv.end_time)
-    except IndexError:
+    except ValueError:
         raise ValueError("Error! Audio slice input params cannot be greater than original audio size. Please try again with correct parameters.")
     
     output_file_path = create_output_path(argv)

--- a/src/interviewkit/slicer.py
+++ b/src/interviewkit/slicer.py
@@ -30,6 +30,7 @@ python interviewkit/slicer.py data/Martine+Barrat_FINAL.mp3 80:30 90:40
 import sys
 from pathlib import Path
 import shutil
+from datetime import timedelta
 
 try:
     import pydub
@@ -42,22 +43,27 @@ if shutil.which("ffmpeg") is None:
     print("  On mac you can: brew install ffmpeg")
     exit(1)
 
-def convert_audio_time_to_msec(audio_time_split_list):
+def convert_time_input_to_time_delta(time_input: str):
     """ Converting mins and secs to msecs for pydub computation """
 
-    if(audio_time_split_list):
-        if(len(audio_time_split_list) == 1):
-            return int(audio_time_split_list[0]) * 60 * 1000
-        elif(len(audio_time_split_list) == 2):
-            return int(audio_time_split_list[0]) * 60 * 1000 + int(audio_time_split_list[1]) * 1000
-        else:
-            print("Error! Audio slice input params invalid. Audio slice supports start/end time in mins or mins:secs format. Please try again with correct input times.")
-            print("Error inside convert_audio_time_to_msec(audio_time_split_list) funtion.")
-            exit(1)
-    else:
-        print("Error! Audio slice input params invalid. Please try again with correct parameters.")
-        print("Error inside convert_audio_time_to_msec(audio_time_split_list) funtion.")
-        exit(1)
+    # Fetching mins and secs from audio input
+    audio_time_split_list = time_input.split(":")
+
+    if not audio_time_split_list:
+        raise ValueError("input time not found")
+    
+    if len(audio_time_split_list) > 2:
+        raise ValueError("Audio slice input params invalid. Audio slice supports start/end time in mins or mins:secs format. Please try again with correct input times") 
+
+    minutes = int(audio_time_split_list[0])
+    
+    seconds = 0
+
+    if len(audio_slicing == 2):
+        seconds = int(audio_time_split_list[1])
+    
+    return timedelta(minutes=minutes, seconds=seconds)
+   
 
 def export_filename(audio_time_list):
     """ Filename for exported file """
@@ -72,6 +78,13 @@ def export_filename(audio_time_list):
         exit(1)
 
 
+def slice_audio(audio, start_time: timedelta , end_time: timedelta):
+    start_time_ms = start_time.total_seconds() * 1000
+    end_time_ms = end_time.total_seconds() * 1000
+    
+    return audio[start_time_ms, end_time_ms]
+
+
 def audio_slicing(path, audio_slice_start_time, audio_slice_end_time):
     """ It reads the original audio and uses start and end input time params to generate sliced audio. """
     
@@ -81,21 +94,20 @@ def audio_slicing(path, audio_slice_start_time, audio_slice_end_time):
     audio = pydub.AudioSegment.from_file(path)
     original_audio_size_ms = audio.duration_seconds * 1000
 
-    # Fetching mins and secs from audio input
-    audio_start_time_list = audio_slice_start_time.split(":")
-    audio_end_time_list = audio_slice_end_time.split(":")
 
     # Converting audio start and end times in msecs
-    audio_start_time = convert_audio_time_to_msec(audio_start_time_list)
-    audio_end_time = convert_audio_time_to_msec(audio_end_time_list)
+    audio_start_time = convert_time_input_to_time_delta(audio_slice_start_time)
+    audio_end_time = convert_time_input_to_time_delta(audio_slice_end_time)
     
     # Check if audio start and end times are within original audio size limits
     if(audio_start_time > original_audio_size_ms or audio_end_time > original_audio_size_ms):
         print("Error! Audio slice input params cannot be greater than original audio size. Please try again with correct parameters.")
         exit(1)
 
-    # Audio slicing process
-    audio = audio[audio_start_time:audio_end_time]
+    sliced_audio = slice_audio(audio, audio_start_time, audio_end_time)
+
+    
+    new_filename = 
 
     # Filename for exported file
     audio_start_time_name = export_filename(audio_start_time_list)

--- a/src/interviewkit/slicer.py
+++ b/src/interviewkit/slicer.py
@@ -73,19 +73,6 @@ def convert_time_input_to_time_delta(time_input: str):
         seconds = int(audio_time_split_list[1])
     
     return timedelta(minutes=minutes, seconds=seconds)
-   
-
-def export_filename(audio_time_list):
-    """ Filename for exported file """
-    
-    if audio_time_list and len(audio_time_list) == 2:
-        return f"{audio_time_list[0]}m{audio_time_list[1]}s"
-    elif audio_time_list and len(audio_time_list) == 1:
-        return f"{audio_time_list[0]}m"
-    else:
-        print("Error! Audio slice input params invalid. Please try again with correct parameters.")
-        print("Error inside export_filename(audio_time_list) funtion.")
-        exit(1)
 
 
 def slice_audio(audio, start_time: timedelta , end_time: timedelta):
@@ -93,24 +80,6 @@ def slice_audio(audio, start_time: timedelta , end_time: timedelta):
     end_time_ms = end_time.total_seconds() * 1000
     
     return audio[start_time_ms, end_time_ms]
-
-
-def audio_slicing(path, audio_slice_start_time, audio_slice_end_time):
-    """ It reads the original audio and uses start and end input time params to generate sliced audio. """
-
-    logging.log(f"Sampling {path} from {audio_slice_start_time} to {audio_slice_end_time}".format(path, audio_slice_start_time, audio_slice_end_time))
-
-
-    # Reading original audio file
-
-
-
-    try:
-        sliced_audio = slice_audio(audio, audio_start_time, audio_end_time)
-    except IndexError:
-        raise ValueError("Error! Audio slice input params cannot be greater than original audio size. Please try again with correct parameters.")
-
-
 
 
 def parse_input(argv):
@@ -131,7 +100,7 @@ def export_as_file(audio: AudioSubset, file_prefix):
     start_time_output = f'{audio.start_time.min}m{audio.start_time.seconds}s'
     end_time_output = f'{audio.end_time.min}m{audio.end_time.seconds}s'
     new_filename =  f"{.parent}/sampled-{start_time_output}-{end_time_output}-{path.name}"
-    sliced_audio.export(new_filename, format="mp3")
+    audio.export(new_filename, format="mp3")
     logging.log(f'Created new file: {new_filename}')
 
 
@@ -141,9 +110,12 @@ def main():
     
     argv = parse_input(sys.argv)
 
-    new_audio = slice_audio(argv.audio, argv.start_time, argv.end_time)
+    try:
+        new_audio = slice_audio(argv.audio, argv.start_time, argv.end_time)
+    except IndexError:
+        raise ValueError("Error! Audio slice input params cannot be greater than original audio size. Please try again with correct parameters.")
 
     export_as_file(new_audio, "./")
-    
+
 if __name__ == '__main__':
     main()

--- a/src/interviewkit/slicer.py
+++ b/src/interviewkit/slicer.py
@@ -18,12 +18,6 @@ This generates:
     data/sampled-70m40s-80m40s-MartineBarrat_FINAL.mp3
     data/sampled-2m-4m-MartineBarrat_FINAL.mp3
 
-Note: 
-The Script currently doesn't support input in hours format, so hours will need to converted to mins:secs format.
-Example: If we want audio from 1hr 20mins 30 secs to 1hr 30mins 40secs, it can be done as shown below:
-1hr 20mins 30 secs = 80mins 30secs
-1hr 30mins 40sec = 90mins 40secs
-
 python interviewkit/slicer.py data/Martine+Barrat_FINAL.mp3 80:30 90:40
 
 """
@@ -32,7 +26,6 @@ from pathlib import Path
 import shutil
 from datetime import timedelta, datetime
 from dataclasses import dataclass
-import logging
 import pydub
 
 


### PR DESCRIPTION
Added types, raises errors

separated parsing input, slicing, and exporting. Separated creation from use

Potential Improvements:
    tried to generalise with time delta so we werent forced to pass ints around
    tried to make use of datetimes string formatting to easily allow for hours, and be able to make changes to expected input. This sort of worked; expected string format is now a constant that we can change. However, now we are limited to clock time (e.g. number of minutes cannot exceed 60). I feel using datetime has actually been more restrictive than I first though, probably should have written a bespoke parser.
